### PR TITLE
add missing #include, missing dependency in docs

### DIFF
--- a/docs/GettingStarted.rst
+++ b/docs/GettingStarted.rst
@@ -8,15 +8,16 @@ Dependencies
 
 Before building and using the Loci Compiler Tools, it's first necessary to build and install their dependencies. This release depends on the following:
 
-* CMake (build system) - *debian package: cmake*
-* Boost Filesystem - *debian package: libboost-filesystem-dev*
-* Boost Program Options - *debian package: libboost-program-options-dev*
-* Boost Regex - *debian package: libboost-regex-dev*
-* Boost System - *debian package: libboost-system-dev*
-* LLVM 3.3/3.4/3.5/3.6 (development build) - *debian package: llvm-dev*
-* Clang 3.3/3.4/3.5/3.6 - *debian package: clang*
-* Sphinx (documentation) - *debian package: python-sphinx*
-* Bison (parser generator) - *debian package: bison*
+* CMake (build system) - *debian package: cmake, arch package: extra/cmake*
+* Boost Filesystem - *debian package: libboost-filesystem-dev, arch package: extra/boost*
+* Boost Program Options - *debian package: libboost-program-options-dev, arch package: extra/boost*
+* Boost Regex - *debian package: libboost-regex-dev, arch package: extra/boost*
+* Boost System - *debian package: libboost-system-dev, arch package: extra/boost*
+* LLVM 3.3/3.4/3.5/3.6 (development build) - *debian package: llvm-dev, arch package: extra/llvm*
+* Clang 3.3/3.4/3.5/3.6 - *debian package: clang, arch package: extra/clang*
+* Sphinx (documentation) - *debian package: python-sphinx, arch package: community/python-sphinx*
+* Bison (parser generator) - *debian package: bison, arch package: core/bison*
+* tinfo (ncurses library routines) - *debian package: libtinfo-dev, arch package: aur/libtinfo*
 
 Also, the following dependencies are optional:
 

--- a/lib/CodeGen/Module.cpp
+++ b/lib/CodeGen/Module.cpp
@@ -2,6 +2,9 @@
 #include <memory>
 #include <string>
 #include <vector>
+#if !defined(NDEBUG) && LOCIC_LLVM_VERSION >= 305
+#include <iostream> // for std::cerr
+#endif
 
 #include <llvm-abi/ABI.hpp>
 


### PR DESCRIPTION
Hi Stephen,

There was a missing header when building with a recent LLVM, and `libtinfo` was not listed as dependency in the Getting Started doc page. Since I was building from my arch linux laptop, I thought I might as well list the required packages' names, as you did for debian. Otherwise it all went pretty smooth, looking forward to play with this language.

Thanks!
Martin
